### PR TITLE
Fix buffer overflow in webvpncontext cookie parsing

### DIFF
--- a/src/worker-http.c
+++ b/src/worker-http.c
@@ -715,6 +715,10 @@ ciphersuite12_finish:
 				}
 
 				nlen = BASE64_DECODE_LENGTH(tmplen);
+				if (nlen < sizeof(ws->sid) ||
+				    nlen > sizeof(ws->sid) + 8)
+					return;
+
 				ret = oc_base64_decode((uint8_t *)p, tmplen,
 						       ws->sid, &nlen);
 				if (ret == 0 || nlen != sizeof(ws->sid)) {


### PR DESCRIPTION
## Summary

Fixes a buffer overflow in the HTTP cookie parser (\worker-http.c\) found by the OneFuzz http-parser-fuzzer.

## Root Cause

In the \HEADER_COOKIE\ handler, the \webvpncontext\ cookie sub-case calls \oc_base64_decode()\ directly into the fixed-size \ws->sid\ buffer (32 bytes) without validating the decoded length first. An oversized base64 cookie value overflows \ws->sid\, corrupting subsequent \worker_st\ struct fields (including \ws->vhost\), leading to a NULL-pointer dereference (SEGV).

The sibling \webvpn\ cookie handler (~30 lines above) already has the correct bounds check pattern.

## Fix

Added bounds validation before the \oc_base64_decode\ call, mirroring the existing \webvpn\ cookie check:
\\\c
if (nlen < sizeof(ws->sid) || nlen > sizeof(ws->sid) + 8)
    return;
\\\

## Related

- ADO PR: [#15713376](https://msazure.visualstudio.com/One/_git/Intune-Svc-MobileAccess/pullrequest/15713376)
- Bug: AB#37929805